### PR TITLE
Do not overlap ping requests; accept any message for activity

### DIFF
--- a/test/mock-server.js
+++ b/test/mock-server.js
@@ -5,6 +5,7 @@ const expect = chai.expect
 const mock = {
 	server: null,
 	drop: false,
+	messages: [],
 	init (options, cb) {
 		mock.server = new Websocket.Server({port: options.port, clientTracking: true}, cb)
 		mock.server.on('connection', (socket) => {
@@ -47,9 +48,10 @@ const mock = {
 		}
 	},
 	handleMessage (socket, rawMessage) {
-		if (mock.drop) return // fall silent
 		const message = JSON.parse(rawMessage)
 		expect(message).to.contain.all.keys('id', 'type')
+		mock.messages.push(message)
+		if (mock.drop) return // fall silent
 		const handlers = {
 			ping: mock.handlePing,
 			subscribe: mock.handleSubscribe,


### PR DESCRIPTION
Separate out the purposes of ping requests for measuring latency and connection liveliness a bit.

For connection liveliness, switch to accepting *any* message, not just pongs.
This in turn allows us to keep exactly one ping in flight, and not resending them while the connection is busy.

Should have the following effects:

- While messages are still coming in, the reconnect is avoided. This gets rid of reconnection loops e.g. when lots of subscriptions need to be renewed.
- After an overload situation clears, do not fire multiple pong events in short succession
- Minor benefit of not pouring more oil into the fire on a busy connection.