### PR TITLE
Always settle pending requests and resubmit pending subscribes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,7 @@ export default class RohrpostClient extends EventEmitter {
 	unsubscribe (group) {
 		if (this.socketState !== 'open') {
 			// Connection is down anyway, just cancel subscription
-			delete this._subscriptions[group]
+			delete this._subscriptions[`${group.type}-${group.id}`]
 			return Promise.resolve()
 		}
 		const { id, promise } = this._createRequest('unsubscribe', group)
@@ -258,7 +258,7 @@ export default class RohrpostClient extends EventEmitter {
 		if (this._openRequests != null) {
 			for (const request of Object.values(this._openRequests)) {
 				if (request.type === 'unsubscribe') {
-					delete this._subscriptions[request.args]
+					delete this._subscriptions[`${request.args.type}-${request.args.id}`]
 					request.deferred.resolve()
 				} else {
 					request.deferred.reject(reason)

--- a/src/index.js
+++ b/src/index.js
@@ -143,7 +143,6 @@ export default class RohrpostClient extends EventEmitter {
 
 	_handlePingTimeout () {
 		this._socket.close()
-		this.emit('closed')
 	}
 
 	_send (payload) {

--- a/test/all.test.js
+++ b/test/all.test.js
@@ -151,4 +151,22 @@ describe('Rohrpost Client', () => {
 			})
 		}, 350)
 	})
+	it('should settle all promises on close', (done) => {
+		client = new RohrpostClient(WS_URL, {pingInterval: 50000, token: 'hunter2'})
+		client.once('open', () => {
+			server.drop = true
+			const a = client.subscribe('foo')
+			const b = client.unsubscribe('bar')
+			const c = client.call('baz')
+			client.close()
+			Promise.allSettled([a, b, c]).then(results => {
+				expect(results).eql([
+					{ status: 'rejected', reason: 'Socket was closed' },
+					{ status: 'fulfilled', value: undefined },  // "got your wish"
+					{ status: 'rejected', reason: 'Socket was closed' }
+				])
+				done()
+			})
+		})
+	})
 })


### PR DESCRIPTION
This is a slightly less atomic package, sorry for that. I can try to separate them more if desired.

1. Pending requests were not settled when the socket closed, either because of a reconnect or actively closing. a904c8adaa will fulfill all unsubscribes, and reject the others.
  I was not sure what purpose of the `_openRequests[id] = undefined` should be, apart from making it harder to iterate on the thing, so I replaced that with a `delete`.
2. 72dea102ba introduces a mechanism to save pending `subcribe` on ping timeout (_not_ deliberate .close()) and resubmits them when connection is established. Attaching the old Promise onto the new one is a bit cheeky, but was easier than trying to suppress the _createRequest.
3. Bonus bugfix 1: The `closed` event would be emitted twice on a ping timeout. Not sure if there is some corner case where _socket.on('close') would not be called; we certainly don't have a test for it…
4. Bonus bugfix 2: The "offline unsubscribe" stunt [which I also copied down in a904c8adaa] was not actually working, because `group` ain't the key. Probably the most dubious change in this PR – there is an architectural issue in that it is supposed to be the server's job to "compute" the group key from the group data; but in practice it's this string.